### PR TITLE
Fix: AttributeError

### DIFF
--- a/hpglpreview.py
+++ b/hpglpreview.py
@@ -7,7 +7,7 @@ import hpgl
 import numpy
 
 # fix broken reference to float_ in wxPython 4.2.0
-FloatCanvas.float_ = numpy.float_
+FloatCanvas.float_ = numpy.float64
 
 HPGL2MM = hpgl.hpgl2mm(1)
 


### PR DESCRIPTION
AttributeError: `np.float_` was removed in the NumPy 2.0 release. Use `np.float64` instead.
